### PR TITLE
Fix getTouch() return status upon bounds overflow

### DIFF
--- a/Extensions/Touch.cpp
+++ b/Extensions/Touch.cpp
@@ -141,7 +141,7 @@ uint8_t TFT_eSPI::getTouch(uint16_t *x, uint16_t *y, uint16_t threshold){
 
   convertRawXY(&x_tmp, &y_tmp);
 
-  if (x_tmp >= _width || y_tmp >= _height) return valid;
+  if (x_tmp >= _width || y_tmp >= _height) return false;
 
   _pressX = x_tmp;
   _pressY = y_tmp;


### PR DESCRIPTION
### Issue
- When the post-remapped coordinates exceed screen bounds, `getTouch()` returns a "valid" status without updating the coordinates. This can result in spurious touch detection events at the screen boundaries.
- The spurious touch coordinates may result in `x,y = 0,0` being reported, but it is dependent upon the caller's initialization of x,y prior to the getTouch() call. This error scenario is not differentiated to the caller from a normal press event at the initialized coordinate (eg. 0,0).

### Fix proposed
- The fix sets the return value to "invalid" in the boundary condition to ensure the caller can properly qualify the returned coordinate

### Issue recreation
- Edit TFT_eSPI Touch_calibrate sketch and uncomment the coordinate reporting in the `if (pressed)` clause
- Apply touch pressure near the right (max-x) / bottom (max-y) edge. Imperfect corner calibration and noise will increase the likelihood of the boundary case.
- Look for reports of discontinuous transitions to a 0,0 coordinate
```
x,y = 318,10
x,y = 317,9
x,y = 319,9
x,y = 319,10
x,y = 319,9
x,y = 319,10
x,y = 0,0 [SPURIOUS]
x,y = 319,9
x,y = 0,0 [SPURIOUS]
x,y = 0,0 [SPURIOUS]
x,y = 0,0 [SPURIOUS]
```
